### PR TITLE
Fixing Result behavior.

### DIFF
--- a/scientist-runtime/src/commonMain/kotlin/Experiment.kt
+++ b/scientist-runtime/src/commonMain/kotlin/Experiment.kt
@@ -82,7 +82,7 @@ private constructor(
       } else {
         emptySet()
       }
-    return Result(control, observations - control, mismatched, ignored)
+    return Result(control, observations - control, mismatched - ignored, ignored)
   }
 
   public class Builder<T>() {

--- a/scientist-runtime/src/commonTest/kotlin/ExperimentTest.kt
+++ b/scientist-runtime/src/commonTest/kotlin/ExperimentTest.kt
@@ -173,7 +173,7 @@ class ExperimentTest {
       enabled = true
       control { throw controlException }
       test { throw candidateException }
-      publish { result -> assertThat(result.mismatched.size).isEqualTo(1) }
+      publish { result -> assertThat(result.mismatched).hasSize(1) }
     }
 
     try {
@@ -213,7 +213,7 @@ class ExperimentTest {
       ignore { _, candidate -> candidate.answer.getOrThrow().contains("result") }
       ignore { _, candidate -> candidate.answer.getOrThrow().contains("candidate") }
       publish { result ->
-        assertThat(result.mismatched).hasSize(3)
+        assertThat(result.mismatched).hasSize(1)
         assertThat(result.ignored).hasSize(2)
       }
     }

--- a/scientist-runtime/src/commonTest/kotlin/ObservationTest.kt
+++ b/scientist-runtime/src/commonTest/kotlin/ObservationTest.kt
@@ -15,7 +15,6 @@
  */
 
 import com.adjectivemonk2.scientist.Experiment
-import com.adjectivemonk2.scientist.Result
 import com.varabyte.truthish.assertThat
 import kotlin.test.Test
 
@@ -23,29 +22,23 @@ class ObservationTest {
 
   @Test
   fun testObservation_equals_with_different_class() {
-    var result: Result<String>? = null
     val experiment = Experiment {
       enabled = true
       control { "control result" }
       test { "candidate result" }
-      publish { result = it }
+      publish { result -> assertThat(result.control).isNotEqualTo("candidate result") }
     }
     experiment.run()
-    assertThat(result).isNotNull()
-    assertThat(result!!.control).isNotEqualTo("candidate result")
   }
 
   @Test
   fun testObservation_equals_with_null() {
-    var result: Result<String>? = null
     val experiment = Experiment {
       enabled = true
       control { "control result" }
       test { "candidate result" }
-      publish { result = it }
+      publish { result -> assertThat(result.control).isNotEqualTo(null) }
     }
     experiment.run()
-    assertThat(result).isNotNull()
-    assertThat(result!!.control).isNotEqualTo(null)
   }
 }


### PR DESCRIPTION
Mismatched will no longer include ignored observations. Fixed a few test cases to follow the same standard.